### PR TITLE
Update the LEDs API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "portmidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ref_slice 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,6 +58,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "portmidi"
 version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ref_slice"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -107,6 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum launchpad 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79cc83defa9cc94427857dcc14523f69d761fa785201c941c4eb13f3e6e9bc41"
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum portmidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e72656dc8167fc128af6ea91224ab4cb9a584cb1ecdcf955a31dbcf3f888747"
+"checksum ref_slice 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "825740057197b7d43025e7faf6477eaabc03434e153233da02d1f44602f71527"
 "checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3bc443ded17b11305ffffe6b37e2076f328a5a8cb6aa877b1b98f77699e98b5"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,3 +10,4 @@ documentation = "https://docs.rs/launchpad"
 
 [dependencies]
 portmidi = "0.2.4"
+ref_slice = "1.1.1"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate portmidi as pm;
+extern crate ref_slice;
 
 mod color;
 mod launchpad;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,50 +104,50 @@ fn run() {
     thread::sleep(Duration::from_millis(500));
 
     println!("Bottom Right to Top Left");
-    lpad.light_leds(&vec![&ColorLed {position: 11, color: 41,},
-                          &ColorLed {position: 22, color: 41,},
-                          &ColorLed {position: 33, color: 41,},
-                          &ColorLed {position: 44, color: 41,},
-                          &ColorLed {position: 55, color: 41,},
-                          &ColorLed {position: 66, color: 41,},
-                          &ColorLed {position: 77, color: 41,},
-                          &ColorLed {position: 88, color: 41,},]);
+    lpad.light_leds(&vec![ColorLed {position: 11, color: 41,},
+                          ColorLed {position: 22, color: 41,},
+                          ColorLed {position: 33, color: 41,},
+                          ColorLed {position: 44, color: 41,},
+                          ColorLed {position: 55, color: 41,},
+                          ColorLed {position: 66, color: 41,},
+                          ColorLed {position: 77, color: 41,},
+                          ColorLed {position: 88, color: 41,},]);
 
     thread::sleep(Duration::from_millis(500));
 
     println!("Bottom Left to Top Right");
-    lpad.light_leds(&vec![&ColorLed {position: 81, color: 5,},
-                          &ColorLed {position: 72, color: 5,},
-                          &ColorLed {position: 63, color: 5,},
-                          &ColorLed {position: 54, color: 5,},
-                          &ColorLed {position: 45, color: 5,},
-                          &ColorLed {position: 36, color: 5,},
-                          &ColorLed {position: 27, color: 5,},
-                          &ColorLed {position: 18, color: 5,},]);
+    lpad.light_leds(&vec![ColorLed {position: 81, color: 5,},
+                          ColorLed {position: 72, color: 5,},
+                          ColorLed {position: 63, color: 5,},
+                          ColorLed {position: 54, color: 5,},
+                          ColorLed {position: 45, color: 5,},
+                          ColorLed {position: 36, color: 5,},
+                          ColorLed {position: 27, color: 5,},
+                          ColorLed {position: 18, color: 5,},]);
 
     thread::sleep(Duration::from_millis(500));
 
     println!("Right controls on");
-    lpad.light_leds(&vec![&ColorLed {position: 19, color: 3,},
-                          &ColorLed {position: 29, color: 3,},
-                          &ColorLed {position: 39, color: 3,},
-                          &ColorLed {position: 49, color: 3,},
-                          &ColorLed {position: 59, color: 3,},
-                          &ColorLed {position: 69, color: 3,},
-                          &ColorLed {position: 79, color: 3,},
-                          &ColorLed {position: 89, color: 3,},]);
+    lpad.light_leds(&vec![ColorLed {position: 19, color: 3,},
+                          ColorLed {position: 29, color: 3,},
+                          ColorLed {position: 39, color: 3,},
+                          ColorLed {position: 49, color: 3,},
+                          ColorLed {position: 59, color: 3,},
+                          ColorLed {position: 69, color: 3,},
+                          ColorLed {position: 79, color: 3,},
+                          ColorLed {position: 89, color: 3,},]);
 
     thread::sleep(Duration::from_millis(500));
 
     println!("Top controls on");
-    lpad.light_leds(&vec![&ColorLed {position: 104, color: 4,},
-                          &ColorLed {position: 105, color: 4,},
-                          &ColorLed {position: 106, color: 4,},
-                          &ColorLed {position: 107, color: 4,},
-                          &ColorLed {position: 108, color: 4,},
-                          &ColorLed {position: 109, color: 4,},
-                          &ColorLed {position: 110, color: 4,},
-                          &ColorLed {position: 111, color: 4,},]);
+    lpad.light_leds(&vec![ColorLed {position: 104, color: 4,},
+                          ColorLed {position: 105, color: 4,},
+                          ColorLed {position: 106, color: 4,},
+                          ColorLed {position: 107, color: 4,},
+                          ColorLed {position: 108, color: 4,},
+                          ColorLed {position: 109, color: 4,},
+                          ColorLed {position: 110, color: 4,},
+                          ColorLed {position: 111, color: 4,},]);
 
 
     thread::sleep(Duration::from_millis(500));


### PR DESCRIPTION
No need to have reference to an array of references, so just have reference to an array of objects instead.
This goes for:
- ColorLed
- ColorColumn
- ColorRow